### PR TITLE
Added support for internationalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,29 @@ When using this technique it is recommended to have a seperate dom element for e
 Note about data-uris: IE versions lower than 8 do not understand data-uris. grunt-reduce adds a fallback to get the original image using conditional comments for these old IE versions.
 
 
+# Internationalization
+Internationalization is optional, and is done by parsing in a `locales` key to the grunt reduce configration like so:
+
+``` javascript
+module.exports = function( grunt ) {
+  'use strict';
+
+  grunt.initConfig({
+    reduce: {
+        // Source folder
+        root: 'app', // Default: 'app',
+
+        // Build destination folder
+        outRoot: 'dist', // Default: 'dist',
+        locales: 'da,en'
+    }
+  })
+}
+```
+
+Please read the [internationalization documentation](https://github.com/assetgraph/assetgraph-builder#internationalization) in Asset Graph Builder project for more information on the subject.
+
+
 # Tools used
 * Assetgraph: https://github.com/One-com/assetgraph
 * Assetgraph-builder: https://github.com/One-com/assetgraph-builder

--- a/tasks/grunt-reduce.js
+++ b/tasks/grunt-reduce.js
@@ -27,6 +27,15 @@ module.exports = function (grunt) {
             asyncScripts = config.asyncScripts === false ? false : true,
             sharedBundles = config.sharedBundles === false ? false : true;
 
+        // Support for locales
+        var locales;
+        if (typeof config.locales === 'string') {
+            // split the defined locales and normalize them
+            locales = config.locales.split(',').map(function (localeId) {
+                return localeId && localeId.replace(/-/g, '_').toLowerCase();
+            });
+        }
+
         var loadAssets = [
             '*.html',
             '.htaccess',
@@ -76,7 +85,8 @@ module.exports = function (grunt) {
                 asyncScripts: asyncScripts,
                 cdnRoot: cdnRoot,
                 noCompress: config.pretty || false,
-                sharedBundles: sharedBundles
+                sharedBundles: sharedBundles,
+                localeIds: locales
             })
             .writeAssetsToDisc({url: /^file:/, isLoaded: true}, outRoot)
             .if(cdnRoot)


### PR DESCRIPTION
Add `locales: 'en,da'` to the grunt reduce configuration. This will make asset graph build an english and danish version. Read the section about internationalization in the asset graph builder documentation for more info.
