### PR TITLE
Update to the assetgraph-builder 5 prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": "*"
   },
   "dependencies": {
-    "assetgraph-builder": "^4.0.1",
+    "assetgraph-builder": "^5.0.0-8",
     "chalk": "^1.1.1",
     "urltools": "0.2.0"
   },

--- a/tasks/grunt-reduce.js
+++ b/tasks/grunt-reduce.js
@@ -30,7 +30,8 @@ module.exports = function (grunt) {
             scss = config.scss === false ? false : true,
             fileRev = config.fileRev === false ? false : true,
             asyncScripts = config.asyncScripts === false ? false : true,
-            sharedBundles = config.sharedBundles === false ? false : true;
+            sharedBundles = config.sharedBundles === false ? false : true,
+            subResourceIntegrity = config.subResourceIntegrity === false ? false : true;
 
         // Support for locales
         var localeIds;
@@ -89,7 +90,8 @@ module.exports = function (grunt) {
                 noCompress: config.pretty || false,
                 sharedBundles: sharedBundles,
                 stripDebug: !(config.pretty || false),
-                localeIds: localeIds
+                localeIds: localeIds,
+                subResourceIntegrity: subResourceIntegrity
             })
             .writeAssetsToDisc({url: /^file:/, isLoaded: true}, outRoot)
             .if(cdnRoot)

--- a/tasks/grunt-reduce.js
+++ b/tasks/grunt-reduce.js
@@ -31,7 +31,8 @@ module.exports = function (grunt) {
             fileRev = config.fileRev === false ? false : true,
             asyncScripts = config.asyncScripts === false ? false : true,
             sharedBundles = config.sharedBundles === false ? false : true,
-            subResourceIntegrity = config.subResourceIntegrity === false ? false : true;
+            subResourceIntegrity = config.subResourceIntegrity === false ? false : true,
+            contentSecurityPolicy = config.contentSecurityPolicy === false ? false : true;
 
         // Support for locales
         var localeIds;
@@ -91,7 +92,8 @@ module.exports = function (grunt) {
                 sharedBundles: sharedBundles,
                 stripDebug: !(config.pretty || false),
                 localeIds: localeIds,
-                subResourceIntegrity: subResourceIntegrity
+                subResourceIntegrity: subResourceIntegrity,
+                contentSecurityPolicy: contentSecurityPolicy
             })
             .writeAssetsToDisc({url: /^file:/, isLoaded: true}, outRoot)
             .if(cdnRoot)

--- a/tasks/grunt-reduce.js
+++ b/tasks/grunt-reduce.js
@@ -72,7 +72,6 @@ module.exports = function (grunt) {
 
         new AssetGraph({ root: rootUrl })
             .logEvents()
-            .registerRequireJsConfig()
             .loadAssets(loadAssets)
             .buildProduction({
                 angular: config.angular,


### PR DESCRIPTION
Could be fun to do a prerelease of grunt-reduce linked against the current ag-b 5 prerelease.
